### PR TITLE
Implement custom decoding for LookupEnvelope.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,90 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/Shared/SwiftUI_MVVMApp.swift
+++ b/Shared/SwiftUI_MVVMApp.swift
@@ -10,10 +10,12 @@ import SwiftUI
 @main
 struct SwiftUI_MVVMApp: App {
     var body: some Scene {
-        WindowGroup {
+        _ = try! testDecoding()
+
+        return WindowGroup {
             NavigationView {
-            ContentView(viewModel: SearchViewModel(apiClient: .live))
-                .navigationBarTitle("Podcasts")
+                ContentView(viewModel: SearchViewModel(apiClient: .live))
+                    .navigationBarTitle("Podcasts")
             }
         }
     }

--- a/Shared/SwiftUI_MVVMApp.swift
+++ b/Shared/SwiftUI_MVVMApp.swift
@@ -10,9 +10,7 @@ import SwiftUI
 @main
 struct SwiftUI_MVVMApp: App {
     var body: some Scene {
-        _ = try! testDecoding()
-
-        return WindowGroup {
+        WindowGroup {
             NavigationView {
                 ContentView(viewModel: SearchViewModel(apiClient: .live))
                     .navigationBarTitle("Podcasts")

--- a/SwiftUI-MVVM.xcodeproj/project.pbxproj
+++ b/SwiftUI-MVVM.xcodeproj/project.pbxproj
@@ -102,7 +102,9 @@
 				80BC40112614F37A00034765 /* Tests macOS */,
 				80BC3FF42614F37A00034765 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		80BC3FEB2614F37800034765 /* Shared */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This will help us with our session tomorrow.

Currently the API endpoint we hit to get episodes from a podcast has a really strange format. It returns a dictionary (see [here](https://itunes.apple.com/lookup?id=1251196416&country=US&media=podcast&entity=podcastEpisode&limit=100
) for an example) with the `results`, but the first entry of the `results` array has info about the podcast, whereas all the rest of the elements of `results` has info about each episode. This means we have to do custom decoding logic so that we can discard that first result and just grab the episodes.